### PR TITLE
Fix volumes to publish the real confluence_home path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ USER nobody:nogroup
 EXPOSE 8090
 
 # set volume mount points for installation and home directory
-VOLUME ["/var/atlassian/confluence", "/usr/local/atlassian/confluence"]
+VOLUME ["/usr/local/atlassian/confluence-data", "/usr/local/atlassian/confluence"]
 
 # run ``Atlassian Confluence`` as a foreground process by default
 ENTRYPOINT ["/usr/local/atlassian/confluence/bin/start-confluence.sh"]


### PR DESCRIPTION
This was one of the steps I needed to take to get persistent data stored outside of the container.  If nothing else, this change allows the confluence_home directory to be viewed from a child container that links to this one.

The other change I needed to make locally was removing the `USER nobody:nogroup` directive, as this was causing permission errors when the volume is mounted from a linked container.  Not sure how you'd feel about removing that and running the service as root.
