### PR TITLE
Switching from 'java' to 'openjdk' as the parent Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM openjdk:8
 
 # Setup useful environment variables
 ENV CONF_HOME     /var/atlassian/confluence


### PR DESCRIPTION
As per [https://hub.docker.com/r/library/java/ ](https://hub.docker.com/r/library/java/ )the 'java' Docker image becomes deprecated and 'openjdk' should be used for continued needs:

>DEPRECATED
>This image is officially deprecated in favor of the openjdk image, and will receive no further updates after 2016-12-31 (Dec 31, 2016). Please adjust your usage accordingly.
>The image has been OpenJDK-specific since it was first introduced, and as of 2016-08-10 we also have an ibmjava image, which made it even more clear that each repository should represent one upstream instead of one language stack or community, so this rename reflects that clarity appropriately.

