### PR TITLE
Upstream#43 - ability to set the number of Conflunce log files to keep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN set -x \
     && chown -R daemon:daemon  "${CONF_INSTALL}/temp" \
     && chown -R daemon:daemon  "${CONF_INSTALL}/logs" \
     && chown -R daemon:daemon  "${CONF_INSTALL}/work" \
+    && chown -R daemon:daemon  "${CONF_INSTALL}/confluence/WEB-INF/classes" \
     && echo -e                 "\nconfluence.home=$CONF_HOME" >> "${CONF_INSTALL}/confluence/WEB-INF/classes/confluence-init.properties" \
     && xmlstarlet              ed --inplace \
         --delete               "Server/@debug" \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -25,5 +25,8 @@ if [ -f "${CERTIFICATE}" ]; then
   keytool -noprompt -storepass changeit -keystore ${JAVA_CACERTS} -import -file ${CERTIFICATE} -alias CompanyCA
 fi
 
+if [ -n "${NUMBER_OF_LOG_FILES_TO_KEEP}" ]; then
+  sed -i -r "s/log4j.appender.confluencelog.MaxBackupIndex=[0-9]+/log4j.appender.confluencelog.MaxBackupIndex=${NUMBER_OF_LOG_FILES_TO_KEEP}/g" $CONF_INSTALL/confluence/WEB-INF/classes/log4j.properties
+fi
 
 exec "$@"


### PR DESCRIPTION
fixes #43 - allows to specify `NUMBER_OF_LOG_FILES_TO_KEEP` environment variable.