### PR TITLE
Add docker env option for session timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN set -x \
     && chown -R daemon:daemon  "${CONF_INSTALL}/temp" \
     && chown -R daemon:daemon  "${CONF_INSTALL}/logs" \
     && chown -R daemon:daemon  "${CONF_INSTALL}/work" \
+    && chown -R daemon:daemon  "${CONF_INSTALL}/confluence/WEB-INF/web.xml" \
     && echo -e                 "\nconfluence.home=$CONF_HOME" >> "${CONF_INSTALL}/confluence/WEB-INF/classes/confluence-init.properties" \
     && xmlstarlet              ed --inplace \
         --delete               "Server/@debug" \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -25,5 +25,8 @@ if [ -f "${CERTIFICATE}" ]; then
   keytool -noprompt -storepass changeit -keystore ${JAVA_CACERTS} -import -file ${CERTIFICATE} -alias CompanyCA
 fi
 
+if [ -n "${SESSION_TIMEOUT}" ]; then
+  xmlstarlet ed --inplace --pf --ps -N 'ns=http://java.sun.com/xml/ns/javaee' --update '//ns:session-config/ns:session-timeout' --value "${SESSION_TIMEOUT}" "${CONF_INSTALL}/confluence/WEB-INF/web.xml"
+fi
 
 exec "$@"


### PR DESCRIPTION
Confluence has a default session timeout of one hour and no way to adjust this via the application UI.
The confluence docs describe how to modify the `web.xml` in order to adjust the session timeout.
https://confluence.atlassian.com/confkb/how-to-adjust-the-session-timeout-for-confluence-126910597.html
This change adds a new step on container startup that if the env variable `SESSION_TIMEOUT` is set
modifies the appropriated XML values.