### PR TITLE
fix(dockerfile): Added missing libs for tinymce-plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV CERTIFICATE   $CONF_HOME/certificate
 # Install Atlassian Confluence and hepler tools and setup initial home
 # directory structure.
 RUN set -x \
-    && apk --no-cache add curl xmlstarlet bash \
+    && apk --no-cache add curl xmlstarlet bash ttf-freefont \
     && mkdir -p                "${CONF_HOME}" \
     && chmod -R 700            "${CONF_HOME}" \
     && chown daemon:daemon     "${CONF_HOME}" \


### PR DESCRIPTION
Had some problems using the editor (aside from synchrony). The tinymceplugin would trigger alot of HTTP 500 error codes on routes like

```
/plugins/servlet/roadmap/image/placeholder/..
/plugins/servlet/confluence/placeholder/macro/..
```
and so on as soon as I tried to edit the demo space frontpage with the three profile images.

Error was

```
java.lang.NullPointerException
    at sun.awt.FontConfiguration.getVersion(FontConfiguration.java:1264)

Stack Trace:
java.lang.NullPointerException
    at sun.awt.FontConfiguration.getVersion(FontConfiguration.java:1264)
    at sun.awt.FontConfiguration.readFontConfigFile(FontConfiguration.java:219)
    at sun.awt.FontConfiguration.init(FontConfiguration.java:107)
    at sun.awt.X11FontManager.createFontConfiguration(X11FontManager.java:774)
    at sun.font.SunFontManager$2.run(SunFontManager.java:431)
    at java.security.AccessController.doPrivileged(Native Method)
    at sun.font.SunFontManager.<init>(SunFontManager.java:376)
    at sun.awt.FcFontManager.<init>(FcFontManager.java:35)
    at sun.awt.X11FontManager.<init>(X11FontManager.java:57)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
    at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
    at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
    at java.lang.Class.newInstance(Class.java:442)
    at sun.font.FontManagerFactory$1.run(FontManagerFactory.java:83)
    at java.security.AccessController.doPrivileged(Native Method)
    at sun.font.FontManagerFactory.getInstance(FontManagerFactory.java:74)
    at sun.font.SunFontManager.getInstance(SunFontManager.java:250)
    at sun.font.FontDesignMetrics.getMetrics(FontDesignMetrics.java:264)
    at sun.java2d.SunGraphics2D.getFontMetrics(SunGraphics2D.java:864)
    at com.atlassian.confluence.tinymceplugin.placeholder.DefaultPlaceholderImageFactory.getFontMetrics(DefaultPlaceholderImageFactory.java:210)

(300 more lines...)
```

solution was to install the basic ttf-freefont package (and deps). Those errors are now gone.