### PR TITLE
Fix #62 missing fontconfig and dejavu-ttf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV CONF_VERSION  6.3.4
 ENV JAVA_CACERTS  $JAVA_HOME/jre/lib/security/cacerts
 ENV CERTIFICATE   $CONF_HOME/certificate
 
-# Install Atlassian Confluence and hepler tools and setup initial home
+# Install Atlassian Confluence and helper tools and setup initial home
 # directory structure.
 RUN set -x \
     && apk --no-cache add curl xmlstarlet bash fontconfig ttf-dejavu \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV CERTIFICATE   $CONF_HOME/certificate
 # Install Atlassian Confluence and hepler tools and setup initial home
 # directory structure.
 RUN set -x \
-    && apk --no-cache add curl xmlstarlet bash \
+    && apk --no-cache add curl xmlstarlet bash fontconfig ttf-dejavu \
     && mkdir -p                "${CONF_HOME}" \
     && chmod -R 700            "${CONF_HOME}" \
     && chown daemon:daemon     "${CONF_HOME}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV CERTIFICATE   $CONF_HOME/certificate
 # Install Atlassian Confluence and helper tools and setup initial home
 # directory structure.
 RUN set -x \
-    && apk --no-cache add curl xmlstarlet bash fontconfig ttf-dejavu \
+    && apk --no-cache add curl xmlstarlet bash ttf-dejavu \
     && mkdir -p                "${CONF_HOME}" \
     && chmod -R 700            "${CONF_HOME}" \
     && chown daemon:daemon     "${CONF_HOME}" \


### PR DESCRIPTION
> Without this, some Confluence macros do not work (repro'd for the Page Tree macro). The POST request for returns a 500 error, caused by a NullPointerException in Java which in turn is caused by the lack of fonts and/or libfontconfig. Relevant issue here: docker-library/openjdk#73
– @agronholm 