### PR TITLE
Add libc6-compat to packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV CERTIFICATE   $CONF_HOME/certificate
 # Install Atlassian Confluence and helper tools and setup initial home
 # directory structure.
 RUN set -x \
-    && apk --no-cache add curl xmlstarlet bash ttf-dejavu \
+    && apk --no-cache add curl xmlstarlet bash ttf-dejavu libc6-compat \
     && mkdir -p                "${CONF_HOME}" \
     && chmod -R 700            "${CONF_HOME}" \
     && chown daemon:daemon     "${CONF_HOME}" \


### PR DESCRIPTION
This should fix issue #60 (which is caused by snappy JNI library not loading). The JNI is linked to libc.so.6 / libm.so.6, which are only provided in the Alpine libc6-compat package as symlinks.

In addition, this fixes my issue that the JIRA table macro is broken, as this also depends  on the snappy JNI.