### PR TITLE
Added Atlassian Crowd SSO integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@
 .repl_history
 build/
 
+## Specific to RubyMine
+.idea
+
 ## Documentation cache and generated files:
 /.yardoc/
 /_yardoc/

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN set -x \
     && chown -R daemon:daemon  "${CONF_INSTALL}/temp" \
     && chown -R daemon:daemon  "${CONF_INSTALL}/logs" \
     && chown -R daemon:daemon  "${CONF_INSTALL}/work" \
+    && chown daemon:daemon     "${CONF_INSTALL}/confluence/WEB-INF/classes/seraph-config.xml" \
     && echo -e                 "\nconfluence.home=$CONF_HOME" >> "${CONF_INSTALL}/confluence/WEB-INF/classes/confluence-init.properties" \
     && xmlstarlet              ed --inplace \
         --delete               "Server/@debug" \
@@ -38,6 +39,7 @@ RUN set -x \
         --delete               "Server/Service/Engine/Host/Context/@debug" \
                                "${CONF_INSTALL}/conf/server.xml" \
     && touch -d "@0"           "${CONF_INSTALL}/conf/server.xml" \
+    && touch -d "@0"           "${CONF_INSTALL}/confluence/WEB-INF/classes/seraph-config.xml" \
     && chown daemon:daemon     "${JAVA_CACERTS}"
 
 # Use the default unprivileged account. This could be considered bad practice

--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ You can configure a small set of things by supplying the following environment v
 | X_PROXY_PORT           | Sets the Tomcat Connectors `ProxyPort` attribute |
 | X_PROXY_SCHEME         | If set to `https` the Tomcat Connectors `secure=true` and `redirectPort` equal to `X_PROXY_PORT`   |
 | X_PATH                 | Sets the Tomcat connectors `path` attribute |
+| X_CROWD_SSO            | Set to `true` to enable SSO via Atlassian Crowd
+
+## How to enable SSO via Crowd
+
+Setting X_CROWD_SSO to `true` will do two things:
+
+- enable the *ConfluenceCrowdSSOAuthenticator*
+- tell Confluence to load `crowd-properties.conf` from `/var/atlassian/confluence` **(It is your responsibility to put it there!)**
+
+**Warning:** You have to setup the Crowd user directory in Confluence beforehand. After enabling the *ConfluenceCrowdSSOAuthenticator*, you are not able to log in using local accounts anymore.
+
+See the [official Documentation](https://confluence.atlassian.com/crowd/integrating-crowd-with-atlassian-confluence-198573.html) for more information.
 
 ## Contributions
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -21,6 +21,13 @@ if [ "$(stat -c "%Y" "${CONF_INSTALL}/conf/server.xml")" -eq "0" ]; then
   fi
 fi
 
+if [ "$(stat -c "%Y" "${CONF_INSTALL}/confluence/WEB-INF/classes/seraph-config.xml")" -eq "0" ]; then
+  if [ "${X_CROWD_SSO}" = "true" ]; then
+    xmlstarlet ed --inplace -u "/security-config/authenticator[@class='com.atlassian.confluence.user.ConfluenceAuthenticator']/@class" -v "com.atlassian.confluence.user.ConfluenceCrowdSSOAuthenticator" "${CONF_INSTALL}/confluence/WEB-INF/classes/seraph-config.xml"
+    export CATALINA_OPTS="${CATALINA_OPTS} -Dcrowd.properties=${CONF_HOME}/crowd.properties"
+  fi
+fi
+
 if [ -f "${CERTIFICATE}" ]; then
   keytool -noprompt -storepass changeit -keystore ${JAVA_CACERTS} -import -file ${CERTIFICATE} -alias CompanyCA
 fi


### PR DESCRIPTION
The will enable login via Crowd SSO.
When _X_CROWD_SSO_ is set to _true_, the default authenticator implementation will be changed to _ConfluenceCrowdSSOAuthenticator_. Also, _-Dcrowd.properties=${CONF_HOME}/crowd.properties_ is appended to _CATALINA_OPTS_