### PR TITLE
Added gcompat to packages in order to fix synchrony / snappy runtime linking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV CERTIFICATE   $CONF_HOME/certificate
 # Install Atlassian Confluence and helper tools and setup initial home
 # directory structure.
 RUN set -x \
-    && apk --no-cache add curl xmlstarlet bash ttf-dejavu libc6-compat \
+    && apk --no-cache add curl xmlstarlet bash ttf-dejavu libc6-compat gcompat \
     && mkdir -p                "${CONF_HOME}" \
     && chmod -R 700            "${CONF_HOME}" \
     && chown daemon:daemon     "${CONF_HOME}" \


### PR DESCRIPTION
At runtime synchrony extracts a native library to `/tmp/snappy-<...>-libsnappyjava.so` which in turn requires the `ld-linux-x86-64.so.2` library. The latter is not provided by Alpine's `musl` package but can be added by installing the `gcompat` package. This is required in addition to the `libc6-compat` package, which is already present in the image.

See:
- https://pkgs.alpinelinux.org/package/edge/community/x86_64/gcompat
- https://pkgs.alpinelinux.org/contents?branch=edge&name=gcompat&arch=x86_64&repo=community

This can be verified by starting up a container with this image and then running `ldd` against the extracted library:

```
/tmp # ldd snappy-1.1.0.1-f808b101-0f46-4328-8703-3d3490f4ae01-libsnappyjava.so 
	ldd (0x7fcbfcf27000)
	libm.so.6 => ldd (0x7fcbfcf27000)
	libc.so.6 => ldd (0x7fcbfcf27000)
	ld-linux-x86-64.so.2 => /lib/ld-linux-x86-64.so.2 (0x7fcbfccd9000)
```
`/lib/ld-linux-x86-64.so.2` is provided by the `gcompat` package in this case.

If this is not installed the snappy library cannot be loaded, which results in errors when loading the Confluence editor. The `atlassian-synchrony.log` file will contain log entries with a JSON object containing such stacktraces in this case (reformatted for better readability):
```
clojure.lang.ExceptionInfo: Could not initialize class org.xerial.snappy.Snappy {:type :server-error, :source :server}
	at clojure.core$ex_info.invokeStatic(core.clj:4725)
	at synchrony.sync.messages$ex_info_from_error_message.invokeStatic(messages.cljc:29)
	at synchrony.sync.connection$request_BANG_$fn__31271.invoke(connection.cljc:92)
	at synchrony.http.entity-api.(take?)(entity_api.clj:493)
	at synchrony.http.entity_api$content_reconciliation$fn__48540.invoke(entity_api.clj:472)
	at synchrony.http.entity-api.(take?)(entity_api.clj:536)
	at synchrony.http.entity_api$put_revision_handler$fn__48739.invoke(entity_api.clj:518)
	at clojure.lang.AFn.run(AFn.java:22)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

Installing the `gcompat` package lets the linker resolve the snappy library dependencies and thereby fixes the Confluence editor when enabling synchrony.