### PR TITLE
MOD: upgrade 8.5.2 with  openjdk:17-alpine&Mysql8-connector

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN set -x \
     && chown daemon:daemon     "${CONF_HOME}" \
     && mkdir -p                "${CONF_INSTALL}/conf" \
     && curl -Ls                "https://www.atlassian.com/software/confluence/downloads/binary/atlassian-confluence-${CONF_VERSION}.tar.gz" | tar -xz --directory "${CONF_INSTALL}" --strip-components=1 --no-same-owner \
-    && curl -Ls                "https://cdn.mysql.com/archives/mysql-connector-java-8.0/mysql-connector-java-8.0.28.tar.gz" | tar -xz --directory "${CONF_INSTALL}/confluence/WEB-INF/lib" --strip-components=1 --no-same-owner "mysql-connector-java-8.0.28/mysql-connector-java-8.0.28.jar" \    && chmod -R 700            "${CONF_INSTALL}/conf" \
+    && curl -Ls                "https://cdn.mysql.com/archives/mysql-connector-java-8.0/mysql-connector-java-8.0.28.tar.gz" | tar -xz --directory "${CONF_INSTALL}/confluence/WEB-INF/lib" --strip-components=1 --no-same-owner "mysql-connector-java-8.0.28/mysql-connector-java-8.0.28.jar" \
+    && chmod -R 700            "${CONF_INSTALL}/conf" \
     && chmod -R 700            "${CONF_INSTALL}/temp" \
     && chmod -R 700            "${CONF_INSTALL}/logs" \
     && chmod -R 700            "${CONF_INSTALL}/work" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM openjdk:8-alpine
+FROM  openjdk:17-alpine
 
 # Setup useful environment variables
 ENV CONF_HOME     /var/atlassian/confluence
 ENV CONF_INSTALL  /opt/atlassian/confluence
 ENV CONF_VERSION  8.5.2
 
-ENV JAVA_CACERTS  $JAVA_HOME/jre/lib/security/cacerts
+ENV JAVA_CACERTS  $JAVA_HOME/lib/security/cacerts
 ENV CERTIFICATE   $CONF_HOME/certificate
 
 # Install Atlassian Confluence and helper tools and setup initial home
@@ -17,8 +17,7 @@ RUN set -x \
     && chown daemon:daemon     "${CONF_HOME}" \
     && mkdir -p                "${CONF_INSTALL}/conf" \
     && curl -Ls                "https://www.atlassian.com/software/confluence/downloads/binary/atlassian-confluence-${CONF_VERSION}.tar.gz" | tar -xz --directory "${CONF_INSTALL}" --strip-components=1 --no-same-owner \
-    && curl -Ls                "https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.44.tar.gz" | tar -xz --directory "${CONF_INSTALL}/confluence/WEB-INF/lib" --strip-components=1 --no-same-owner "mysql-connector-java-5.1.44/mysql-connector-java-5.1.44-bin.jar" \
-    && chmod -R 700            "${CONF_INSTALL}/conf" \
+    && curl -Ls                "https://cdn.mysql.com/archives/mysql-connector-java-8.0/mysql-connector-java-8.0.28.tar.gz" | tar -xz --directory "${CONF_INSTALL}/confluence/WEB-INF/lib" --strip-components=1 --no-same-owner "mysql-connector-java-8.0.28/mysql-connector-java-8.0.28.jar" \    && chmod -R 700            "${CONF_INSTALL}/conf" \
     && chmod -R 700            "${CONF_INSTALL}/temp" \
     && chmod -R 700            "${CONF_INSTALL}/logs" \
     && chmod -R 700            "${CONF_INSTALL}/work" \


### PR DESCRIPTION
<!---
  Please read the CONTRIBUTING.md file before submitting a new pull request

  Note: Version bumping is performed automagically according to Atlassians own
  version feed by automation. If the version is behind of latest, please contact
  Atlassian about updating their feed to rectify this.
-->

*Issue #, if available:*

*Description of changes:*

1. Update the base Docker image from jdk8 to jdk17,because confluence does not support JDK8 anymore from version 8.0 ;
2. update mysql driver to mysql8-connector , as confluence 8.x does not support mysql5.7 anymore. I choose connector vrsion 8.0.28 beause myql change utf8 encoding and this may produce potential bug. 
> this is confluence doc: 
> There is a known issue when running Confluence with MySQL 8.0.29 and later due to a [change to the UTF8 alias in MySQL](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-29.html). We're working on a fix, but if you have Confluence 7.3 or later, you can change the character set and collation to UTF8MB4 to avoid this issue. See [How to Fix the Collation and Character Set of a MySQL Database manually](https://confluence.atlassian.com/kb/how-to-fix-the-collation-and-character-set-of-a-mysql-database-manually-744326173.html).


By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
